### PR TITLE
Augment istanbul-report type for TS projects

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -15,6 +15,9 @@
 # Source
 !lib/*.js
 
+# Types
+!typings/*.d.ts
+
 # Assets
 !assets/**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-reporter-html-monorepo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-reporter-html-monorepo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -753,14 +753,12 @@
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
-      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==",
-      "dev": true
+      "integrity": "sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw=="
     },
     "@types/istanbul-lib-report": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
       "integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-coverage": "*"
       }
@@ -769,7 +767,6 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-3.0.1.tgz",
       "integrity": "sha512-c3mAZEuK0lvBp8tmuL74XRKn1+y2dcwOUpH7x4WrF6gk1GIgiluDRgMYQtw2OFcBvAJWlt6ASU3tSqxp0Uu0Aw==",
-      "dev": true,
       "requires": {
         "@types/istanbul-lib-report": "*"
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-reporter-html-monorepo",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "A monorepo-focused HTML reporter for istanbul/nyc",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "istanbul-reporter-html-monorepo",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "A monorepo-focused HTML reporter for istanbul/nyc",
   "main": "index.js",
   "scripts": {
@@ -8,6 +8,7 @@
     "lint": "eslint .",
     "lint-fix": "eslint --fix ."
   },
+  "typings": "typings/index.d.ts",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/HBOCodeLabs/istanbul-reporter-html-monorepo.git"
@@ -23,6 +24,7 @@
   },
   "homepage": "https://github.com/HBOCodeLabs/istanbul-reporter-html-monorepo#readme",
   "dependencies": {
+    "@types/istanbul-reports": "*",
     "html-escaper": "^2.0.0",
     "istanbul-lib-report": "^3.0.0"
   },

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,11 +1,11 @@
 import { ReportOptions, HtmlOptions } from 'istanbul-reports';
 
-export interface HtmlMonorepoProject {
+export declare interface HtmlMonorepoProject {
   name: string;
   path: string;
 }
 
-export interface HtmlMonorepoOptions extends HtmlOptions {
+export declare interface HtmlMonorepoOptions extends HtmlOptions {
   reportTitle: string;
   projects: HtmlMonorepoProject[];
   defaultProjectName: string;

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -1,0 +1,18 @@
+import { ReportOptions, HtmlOptions } from 'istanbul-reports';
+
+export interface HtmlMonorepoProject {
+  name: string;
+  path: string;
+}
+
+export interface HtmlMonorepoOptions extends HtmlOptions {
+  reportTitle: string;
+  projects: HtmlMonorepoProject[];
+  defaultProjectName: string;
+}
+
+declare module 'istanbul-reports' {
+  interface ReportOptions {
+    'istanbul-reporter-html-monorepo': HtmlMonorepoOptions
+  }
+}


### PR DESCRIPTION
### SUMMARY

Add typings entry so TS projects can use the reporter from code without overriding types.

### DETAILS

Augment the `ReportOptions` interface.  Because usually you will create a report using the `create` method from `istanbul-reports`, passing the name of the package, you'll need to import it first to give you correct typings.

```js
import 'istanbul-reporter-html-monorepo';
```

### CHECKLIST
- [x] Documentation updated (if needed)
- [x] Unit tests exist to cover the code you are changing and validated
- [x] Integration tests exist to cover the code you are changing and validated
